### PR TITLE
SRE-7 Getting credentials decode fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install kubectl
-        uses: qgx-pagamentos/aws-eks-kubectl-set@v1
+        uses: qgx-pagamentos/kubectl-aws-iam-auth@v1
         with:
           base64-kube-config: ${{ secrets.KUBE_CONFIG_DATA }}
           kubectl-version: 1.28.1

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Essa Action disponibiliza o comando `kubectl` para Github Actions.
 
+
+> Você deve usar uma versão kubectl que esteja dentro de uma pequena diferença de versão do cluster control plane do Amazon EKS. Por exemplo, um cliente 1.26 kubectl funciona com clusters Kubernetes 1.25, 1.26 e 1.27.
+
 ## Uso
 
 `.github/workflows/push.yml`
@@ -18,10 +21,11 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install kubectl
-        uses: qgxpagamentos/kubectl-set@v1
+        uses: qgx-pagamentos/aws-eks-kubectl-set@v1
         with:
           base64-kube-config: ${{ secrets.KUBE_CONFIG_DATA }}
-          kubectl-version: v1.22.5
+          kubectl-version: 1.28.1
+          aws-iam-auth-version: 0.6.11
 
       - name: Deploy Kubernetes cluster Service/Deployment
         run: |

--- a/action.yml
+++ b/action.yml
@@ -3,9 +3,11 @@ author: 'QGX Pagamentos'
 description: This action provides kubectl for Github Actions.
 inputs:
   kubectl-version:
-    description: Version of the kubectl CLI to use
+    description: Version of the kubectl CLI to use. Latest stable version will be used if not specified.
     required: false
-    default: v1.22.5
+  aws-iam-auth-version:
+    description: Version of the aws-iam-authenticator to use. Version v0.6.11 will be used if not specified.
+    required: false
   base64-kube-config:
     description: A base64 encoded reference to your authorization file (~/.kube/config)
     required: true
@@ -18,5 +20,6 @@ runs:
     - run: ${GITHUB_ACTION_PATH}/setup.sh
       shell: bash
       env:
+        AWS_IAM_AUTH_VERSION: ${{ inputs.aws-iam-auth-version }}
         BASE64_KUBE_CONFIG: ${{ inputs.base64-kube-config }}
         KUBE_VERSION: ${{ inputs.kubectl-version }}

--- a/setup.sh
+++ b/setup.sh
@@ -4,21 +4,27 @@ set -v # show current command
 
 mkdir $GITHUB_WORKSPACE/bin
 
-echo "KUBE_VERSION: $KUBE_VERSION"
+[[ -n "${KUBE_VERSION}" ]] && KV=$KUBE_VERSION || KV=$(curl -L -s https://dl.k8s.io/release/stable.txt | cut -d'v' -f2)
+[[ -n "${AWS_IAM_AUTH_VERSION}" ]] && AIAV=$AWS_IAM_AUTH_VERSION || AIAV="0.6.11" #Based on https://github.com/kubernetes-sigs/aws-iam-authenticator/tags
 
 # kubectl
-curl -LO "https://dl.k8s.io/release/$KUBE_VERSION/bin/linux/amd64/kubectl"
-curl -LO "https://dl.k8s.io/$KUBE_VERSION/bin/linux/amd64/kubectl.sha256"
+echo "Installing kubectl version: v${KV}"
+curl -LO "https://dl.k8s.io/release/v${KV}/bin/linux/amd64/kubectl"
+curl -LO "https://dl.k8s.io/v${KV}/bin/linux/amd64/kubectl.sha256"
 echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check
 chmod +x kubectl
 
 # aws-iam-authenticator
-curl -LO "https://s3.us-west-2.amazonaws.com/amazon-eks/1.21.2/2021-07-05/bin/linux/amd64/aws-iam-authenticator"
+echo "Installing aws-iam-authenticator version: v${AIAV}"
+curl -Lo aws-iam-authenticator_${AIAV}_linux_amd64 https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v${AIAV}/aws-iam-authenticator_${AIAV}_linux_amd64
+curl -Lo aws-iam-authenticator.txt https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v${AIAV}/authenticator_${AIAV}_checksums.txt
+echo -n "$(egrep "aws-iam-authenticator_${AIAV}_linux_amd64" aws-iam-authenticator.txt | cut -d' ' -f1)  aws-iam-authenticator_${AIAV}_linux_amd64" | sha256sum --check \
+	&& mv aws-iam-authenticator_${AIAV}_linux_amd64 aws-iam-authenticator
 chmod +x aws-iam-authenticator
 
 # moving
 mv kubectl /usr/local/bin/kubectl
-mv aws-iam-authenticator $GITHUB_WORKSPACE/bin
+mv aws-iam-authenticator $GITHUB_WORKSPACE/bin/aws-iam-authenticator
 
 echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
 


### PR DESCRIPTION
Caused by:
```
I0905 21:43:14.527015    1885 round_trippers.go:577] Response Headers:
I0905 21:43:14.527078    1885 helpers.go:264] Connection error: Get https://[REPLACED].gr7.us-east-1.eks.amazonaws.com/openapi/v2?timeout=32s: getting credentials: decoding stdout: no kind "ExecCredential" is registered for version "client.authentication.k8s.io/v1alpha1" in scheme "pkg/client/auth/exec/exec.go:62"
Unable to connect to the server: getting credentials: decoding stdout: no kind "ExecCredential" is registered for version "client.authentication.k8s.io/v1alpha1" in scheme "pkg/client/auth/exec/exec.go:62"
Error: Process completed with exit code 1.
```